### PR TITLE
Joplin version bump 3.5.11

### DIFF
--- a/joplin-bin/.SRCINFO
+++ b/joplin-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = joplin-bin
 	pkgdesc = Note Taking App. Debian Package.
-	pkgver = 3.5.6
+	pkgver = 3.5.11
 	pkgrel = 1
 	url = https://github.com/laurent22/joplin
 	arch = x86_64
@@ -13,7 +13,7 @@ pkgbase = joplin-bin
 	conflicts = joplin-electron
 	conflicts = joplin-beta-appimage
 	options = !debug
-	source_x86_64 = joplin-bin-3.5.6.deb::https://github.com/laurent22/joplin/releases/download/v3.5.6/joplin-3.5.6.deb
-	md5sums_x86_64 = 9fed20e1d5ed0146bfce8f82c485c897
+	source_x86_64 = joplin-bin-3.5.11.deb::https://github.com/laurent22/joplin/releases/download/v3.5.11/joplin-3.5.11.deb
+	md5sums_x86_64 = b04eb47a131907a1ecb77e30f9001d8e
 
 pkgname = joplin-bin

--- a/joplin-bin/PKGBUILD
+++ b/joplin-bin/PKGBUILD
@@ -2,7 +2,7 @@
 
 _pkgname=joplin
 pkgname=${_pkgname}-bin
-pkgver=3.5.6
+pkgver=3.5.11
 pkgrel=1
 pkgdesc="Note Taking App. Debian Package."
 arch=('x86_64')

--- a/joplin-bin/PKGBUILD
+++ b/joplin-bin/PKGBUILD
@@ -25,4 +25,4 @@ package() {
     ln -s "/opt/Joplin/$_pkgname" "$pkgdir/usr/bin/$_pkgname"
 }
 
-md5sums_x86_64=('9fed20e1d5ed0146bfce8f82c485c897')
+md5sums_x86_64=('b04eb47a131907a1ecb77e30f9001d8e')


### PR DESCRIPTION
Greetings

I bumped the version to the latest one. I believe this would build correctly still